### PR TITLE
Explicitly start ``ProgressBar``s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.*
+StereoVision.egg-info/
+external/
+*.pyc

--- a/bin/capture_chessboards
+++ b/bin/capture_chessboards
@@ -61,6 +61,7 @@ def main():
                           " ", Percentage()])
     if not os.path.exists(args.output_folder):
         os.makedirs(args.output_folder)
+    progress.start()
     with ChessboardFinder((args.left, args.right)) as pair:
         for i in range(args.num_pictures):
             frames = pair.get_chessboard(args.columns, args.rows, True)

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with StereoVision.  If not, see <http://www.gnu.org/licenses/>.
 
-from distutils.core import setup
+from setuptools import setup
 
 setup(name="StereoVision",
       version="1.0.0",

--- a/stereovision/ui_utils.py
+++ b/stereovision/ui_utils.py
@@ -96,6 +96,7 @@ def calibrate_folder(args):
                           widgets=[Bar("=", "[", "]"),
                           " ", Percentage()])
     print("Reading input files...")
+    progress.start()
     while args.input_files:
         left, right = args.input_files[:2]
         img_left, im_right = cv2.imread(left), cv2.imread(right)


### PR DESCRIPTION
Perhaps due to a bug in ``progressbar``, this was not required in the past,
although I believe that it was desired. Now all ``ProgressBar``s are explicitly
started, which matches the current API's requirements and fixes #2.