### PR TITLE
support single stream cameras

### DIFF
--- a/stereovision/stereo_cameras.py
+++ b/stereovision/stereo_cameras.py
@@ -54,8 +54,14 @@ class StereoPair(object):
 
         ``devices`` is an iterable containing the device numbers.
         """
-        #: Video captures associated with the ``StereoPair``
-        self.captures = [cv2.VideoCapture(device) for device in devices]
+
+        if devices[0] != devices[1]:
+            #: Video captures associated with the ``StereoPair``
+            self.captures = [cv2.VideoCapture(device) for device in devices]
+        else:
+            # Stereo images come from a single device, as single image
+            self.captures = [cv2.VideoCapture(devices[0])]
+            self.get_frames = self.get_frames_singleimage
 
     def __enter__(self):
         return self
@@ -69,6 +75,17 @@ class StereoPair(object):
     def get_frames(self):
         """Get current frames from cameras."""
         return [capture.read()[1] for capture in self.captures]
+
+    def get_frames_singleimage(self):
+        """
+        Get current left and right frames from a single image,
+        by splitting the image in half.
+        """
+        frame = self.captures[0].read()[1]
+        height, width, colors = frame.shape
+        left_frame = frame[:, :width/2, :]
+        right_frame = frame[:, width/2:, :]
+        return [left_frame, right_frame]
 
     def show_frames(self, wait=0):
         """


### PR DESCRIPTION
With single stream camera I mean that the images of both the
left and right camera are streamed side-by-side in a single image.

The single image is split in half to give two images.

A single stream camera can then be used for example with:

    show_webcam 0 0