### PR TITLE
Updated shebangs to portable format.

### DIFF
--- a/bin/calibrate_cameras
+++ b/bin/calibrate_cameras
@@ -1,4 +1,4 @@
-#!/bin/python
+#!/usr/bin/env python
 ## Copyright (C) 2014 Daniel Lee <lee.daniel.1986@gmail.com>
 #
 # This file is part of StereoVision.

--- a/bin/calibrate_cameras
+++ b/bin/calibrate_cameras
@@ -1,5 +1,6 @@
-#!/usr/bin/env python
-## Copyright (C) 2014 Daniel Lee <lee.daniel.1986@gmail.com>
+#!/usr/bin/env python3
+
+# Copyright (C) 2014 Daniel Lee <lee.daniel.1986@gmail.com>
 #
 # This file is part of StereoVision.
 #
@@ -47,7 +48,6 @@ def main():
                         "chessboard corners.", action="store_true")
     args = parser.parse_args()
 
-    print args.input_folder
     args.input_files = find_files(args.input_folder)
     calibrate_folder(args)
 

--- a/bin/capture_chessboards
+++ b/bin/capture_chessboards
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+
 # Copyright (C) 2014 Daniel Lee <lee.daniel.1986@gmail.com>
 #
 # This file is part of StereoVision.

--- a/bin/capture_chessboards
+++ b/bin/capture_chessboards
@@ -1,4 +1,4 @@
-#!/bin/python
+#!/usr/bin/env python
 # Copyright (C) 2014 Daniel Lee <lee.daniel.1986@gmail.com>
 #
 # This file is part of StereoVision.
@@ -71,8 +71,6 @@ def main():
                 output_path = os.path.join(args.output_folder, filename)
                 cv2.imwrite(output_path, frame)
             progress.update(progress.maxval - (args.num_pictures - i))
-            for i in range(10):
-                pair.show_frames(1)
         progress.finish()
     if args.calibration_folder:
         args.input_files = find_files(args.output_folder)

--- a/bin/images_to_pointcloud
+++ b/bin/images_to_pointcloud
@@ -1,4 +1,4 @@
-#!/bin/python
+#!/usr/bin/env python
 # Copyright (C) 2014 Daniel Lee <lee.daniel.1986@gmail.com>
 #
 # This file is part of StereoVision.

--- a/bin/images_to_pointcloud
+++ b/bin/images_to_pointcloud
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+
 # Copyright (C) 2014 Daniel Lee <lee.daniel.1986@gmail.com>
 #
 # This file is part of StereoVision.

--- a/bin/show_webcams
+++ b/bin/show_webcams
@@ -1,4 +1,4 @@
-#!/bin/python
+#!/usr/bin/env python
 # Copyright (C) 2014 Daniel Lee <lee.daniel.1986@gmail.com>
 #
 # This file is part of StereoVision.

--- a/bin/show_webcams
+++ b/bin/show_webcams
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+
 # Copyright (C) 2014 Daniel Lee <lee.daniel.1986@gmail.com>
 #
 # This file is part of StereoVision.

--- a/bin/tune_blockmatcher
+++ b/bin/tune_blockmatcher
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+
 # Copyright (C) 2014 Daniel Lee <lee.daniel.1986@gmail.com>
 #
 # This file is part of StereoVision.

--- a/bin/tune_blockmatcher
+++ b/bin/tune_blockmatcher
@@ -1,4 +1,4 @@
-#!/bin/python
+#!/usr/bin/env python
 # Copyright (C) 2014 Daniel Lee <lee.daniel.1986@gmail.com>
 #
 # This file is part of StereoVision.
@@ -26,7 +26,7 @@ parameters chosen in the ``BMTuner``'s GUI. Afterwards, report user's chosen
 settings and, if a file for the BM settings is provided, save the most common
 settings to file.
 """
-
+import os
 from argparse import ArgumentParser
 
 import cv2
@@ -58,6 +58,8 @@ def main():
         block_matcher = StereoBM()
     else:
         block_matcher = StereoSGBM()
+    if os.path.exists(args.bm_settings):
+        block_matcher.load_settings(args.bm_settings)
     image_pair = [cv2.imread(image) for image in input_files[:2]]
     input_files = input_files[2:]
     rectified_pair = calibration.rectify(image_pair)

--- a/stereovision/blockmatchers.py
+++ b/stereovision/blockmatchers.py
@@ -111,10 +111,11 @@ class BlockMatcher(object):
 class StereoBM(BlockMatcher):
 
     """A stereo block matching ``BlockMatcher``."""
-
+#cv2.STEREO_BM_PREFILTER_XSOBEL
+#cv2.STEREO_BM_PREFILTER_NORMALIZED_RESPONSE
     parameter_maxima = {"search_range": None,
                        "window_size": 255,
-                       "stereo_bm_preset": cv2.STEREO_BM_NARROW_PRESET}
+                       "stereo_bm_preset": cv2.STEREO_BM_PREFILTER_XSOBEL}
 
     @property
     def search_range(self):
@@ -172,7 +173,7 @@ class StereoBM(BlockMatcher):
                                           ndisparities=self._search_range,
                                           SADWindowSize=self._window_size)
 
-    def __init__(self, stereo_bm_preset=cv2.STEREO_BM_BASIC_PRESET,
+    def __init__(self, stereo_bm_preset=cv2.STEREO_BM_PREFILTER_NORMALIZED_RESPONSE,
                  search_range=80,
                  window_size=21,
                  settings=None):
@@ -360,7 +361,10 @@ class StereoSGBM(BlockMatcher):
 
     def _replace_bm(self):
         """Replace ``_block_matcher`` with current values."""
-        self._block_matcher = cv2.StereoSGBM(minDisparity=self._min_disparity,
+        self._block_matcher = cv2.StereoSGBM_create(self._min_disparity, self._num_disp,
+                                                    self._sad_window_size, self._P1, self._P2,
+                                                    self._max_disparity, speckleWindowSize=self._speckle_window_size, speckleRange=self._speckle_range)
+        """self._block_matcher = cv2.StereoSGBM(minDisparity=self._min_disparity,
                         numDisparities=self._num_disp,
                         SADWindowSize=self._sad_window_size,
                         uniquenessRatio=self._uniqueness,
@@ -369,7 +373,7 @@ class StereoSGBM(BlockMatcher):
                         disp12MaxDiff=self._max_disparity,
                         P1=self._P1,
                         P2=self._P2,
-                        fullDP=self._full_dp)
+                        fullDP=self._full_dp)"""
 
     def __init__(self, min_disparity=16, num_disp=96, sad_window_size=3,
                  uniqueness=10, speckle_window_size=100, speckle_range=32,
@@ -398,7 +402,8 @@ class StereoSGBM(BlockMatcher):
         #: Boolean to use full-scale two-pass dynamic algorithm
         self._full_dp = full_dp
         #: StereoSGBM whose state is controlled
-        self._block_matcher = cv2.StereoSGBM()
+        self._block_matcher = cv2.StereoSGBM_create(min_disparity, num_disp, sad_window_size);
+        #self._block_matcher = cv2.StereoSGBM()
         super(StereoSGBM, self).__init__(settings)
 
     def get_disparity(self, pair):

--- a/stereovision/calibration.py
+++ b/stereovision/calibration.py
@@ -222,17 +222,18 @@ class StereoCalibrator(object):
         flags = (cv2.CALIB_FIX_ASPECT_RATIO + cv2.CALIB_ZERO_TANGENT_DIST +
                  cv2.CALIB_SAME_FOCAL_LENGTH)
         calib = StereoCalibration()
+        print(self.image_size, len(self.object_points), len(self.image_points["left"]), len(self.image_points["right"]))
         (calib.cam_mats["left"], calib.dist_coefs["left"],
          calib.cam_mats["right"], calib.dist_coefs["right"],
          calib.rot_mat, calib.trans_vec, calib.e_mat,
          calib.f_mat) = cv2.stereoCalibrate(self.object_points,
                                             self.image_points["left"],
                                             self.image_points["right"],
+                                            self.image_size,
                                             calib.cam_mats["left"],
                                             calib.dist_coefs["left"],
                                             calib.cam_mats["right"],
                                             calib.dist_coefs["right"],
-                                            self.image_size,
                                             calib.rot_mat,
                                             calib.trans_vec,
                                             calib.e_mat,

--- a/stereovision/stereo_cameras.py
+++ b/stereovision/stereo_cameras.py
@@ -93,10 +93,15 @@ class StereoPair(object):
 
         ``wait`` is the wait interval in milliseconds before the window closes.
         """
-        for window, frame in zip(self.windows, self.get_frames()):
-            cv2.imshow(window, frame)
-        cv2.waitKey(wait)
-
+        while True:
+            frames = self.get_frames()
+            for window, frame in zip(self.windows, frames):
+                cv2.imshow(window, frame)
+            wk = cv2.waitKey(wait)
+            if wk & 0xFF == ord(' '):
+                break
+        return frames
+        
     def show_videos(self):
         """Show video from cameras."""
         while True:
@@ -119,9 +124,10 @@ class ChessboardFinder(StereoPair):
         """
         found_chessboard = [False, False]
         while not all(found_chessboard):
-            frames = self.get_frames()
             if show:
-                self.show_frames(1)
+                frames = self.show_frames(1)
+            else:
+                frames = self.get_frames()
             for i, frame in enumerate(frames):
                 (found_chessboard[i],
                  corners) = cv2.findChessboardCorners(frame, (columns, rows),

--- a/stereovision/ui_utils.py
+++ b/stereovision/ui_utils.py
@@ -178,7 +178,7 @@ class BMTuner(object):
         self.bm_settings = {}
         for parameter in self.block_matcher.parameter_maxima.keys():
             self.bm_settings[parameter] = []
-        cv2.namedWindow(self.window_name)
+        cv2.namedWindow(self.window_name, flags=cv2.WINDOW_NORMAL)
         self._initialize_trackbars()
         self.tune_pair(image_pair)
 

--- a/stereovision/ui_utils.py
+++ b/stereovision/ui_utils.py
@@ -136,8 +136,9 @@ class BMTuner(object):
         try:
             self.block_matcher.__setattr__(parameter, new_value)
         except BadBlockMatcherArgumentError:
+            print('Bad Block')
             return
-        self.update_disparity_map()
+        #self.update_disparity_map()
 
     def _initialize_trackbars(self):
         """
@@ -192,13 +193,16 @@ class BMTuner(object):
         disparity = self.block_matcher.get_disparity(self.pair)
         norm_coeff = 255 / disparity.max()
         cv2.imshow(self.window_name, disparity * norm_coeff / 255)
-        cv2.waitKey()
+        return cv2.waitKey(0)
 
     def tune_pair(self, pair):
         """Tune a pair of images."""
-        self._save_bm_state()
-        self.pair = pair
-        self.update_disparity_map()
+        done = False
+        while not done:
+            self._save_bm_state()
+            self.pair = pair
+            if self.update_disparity_map() & 0xff == ord('q'):
+                done = True
 
     def report_settings(self, parameter):
         """


### PR DESCRIPTION
Tried to fix up on tune_blockmatcher to update the view continually until 'q' is pressed. Now usable.
Load existing bm_settings when given on commandline in tune_blockmatcher.
Bugfix: Moved size argument in cv2.stereoCalibrate to its right place. Was this an unaddressed API-change in python-opencv?
In StereoPair.show_frames, used from ChessboardFinder, continually show new frames until space key is pressed. This enables visual inspection while moving the chessboard around to a new location in view.