### PR TITLE
Enforcing 5 seconds delay, Adding timer overlay.

### DIFF
--- a/bin/capture_chessboards
+++ b/bin/capture_chessboards
@@ -85,6 +85,7 @@ def main():
             show_selected_frames(frames, corners, pair, args, True)
 
         progress.finish()
+        cv2.destroyAllWindows()
 
     if args.calibration_folder:
         args.input_files = find_files(args.output_folder)

--- a/bin/capture_chessboards
+++ b/bin/capture_chessboards
@@ -28,7 +28,7 @@ from progressbar import ProgressBar, Bar, Percentage
 from stereovision.stereo_cameras import ChessboardFinder
 from stereovision.ui_utils import calibrate_folder, CHESSBOARD_ARGUMENTS
 from stereovision.ui_utils import find_files
-
+import time
 
 PROGRAM_DESCRIPTION=(
 "Take a number of pictures with a stereo camera in which a chessboard is "
@@ -63,22 +63,94 @@ def main():
         os.makedirs(args.output_folder)
     progress.start()
     with ChessboardFinder((args.left, args.right)) as pair:
+
+        # Sets initial position of windows, based on image size
+        set_window_position(pair)
+
         for i in range(args.num_pictures):
-            frames = pair.get_chessboard(args.columns, args.rows, True)
+
+            # Introduces a 5 second delay before the camera pair is scanned for new images
+            enforce_delay(pair, 5)
+
+            frames, corners = pair.get_chessboard(args.columns, args.rows, True)
             for side, frame in zip(("left", "right"), frames):
                 number_string = str(i + 1).zfill(len(str(args.num_pictures)))
                 filename = "{}_{}.ppm".format(side, number_string)
                 output_path = os.path.join(args.output_folder, filename)
                 cv2.imwrite(output_path, frame)
+
             progress.update(progress.maxval - (args.num_pictures - i))
-            for i in range(10):
-                pair.show_frames(1)
+
+            # Displays the recent accepted image pair. Helps in generating diverse calibration images.
+            show_selected_frames(frames, corners, pair, args, True)
+
         progress.finish()
+
     if args.calibration_folder:
         args.input_files = find_files(args.output_folder)
         args.output_folder = args.calibration_folder
         args.show_chessboards = True
         calibrate_folder(args)
+
+
+def show_selected_frames(frames, corners, pair, args, draw_corners=False):
+    if draw_corners:
+        for frame, corner in zip(frames, corners):
+            cv2.drawChessboardCorners(frame, (args.columns, args.rows), corner, True)
+
+    cv2.imshow("{} selected".format(pair.windows[0]), frames[0])
+    cv2.imshow("{} selected".format(pair.windows[1]), frames[1])
+
+
+def enforce_delay(pair, delay):
+    """
+    Enforces a delay of 5 seconds. This helps the user to change the chessboard perspective.
+    A timer is displayed indicating the time remaining before the next sample is captured.
+    """
+
+    font = cv2.FONT_HERSHEY_SIMPLEX
+    line_type = cv2.LINE_4
+    font_scale = 6.0
+    line_thickness = 4
+
+    start_time = time.time()
+    now = start_time
+
+    while now - start_time < delay:
+
+        frames = pair.get_frames()
+
+        # Calculates the time remaining before the next sample is captured
+        time_remaining = "{:.2f}".format(delay - now + start_time)
+        text_size = cv2.getTextSize(time_remaining, font, font_scale, line_thickness)[0]
+
+        # Calculates the position of the text
+        text_x = (frames[0].shape[1] - text_size[0]) / 2
+        text_y = (frames[0].shape[0] + text_size[1]) / 2
+
+        for frame, window in zip(frames, pair.windows):
+            cv2.putText(frame, time_remaining, (text_x, text_y), font, font_scale, (255, 50, 50),
+                        line_thickness, line_type)
+            cv2.imshow(window, frame)
+
+        cv2.waitKey(1)
+        now = time.time()
+
+
+def set_window_position(pair):
+    frames = pair.get_frames()
+    pair.show_frames(1)
+
+    # Setting initial position of cameras
+    cv2.moveWindow(pair.windows[0], 0, 0)
+    cv2.moveWindow(pair.windows[1], frames[1].shape[1], 0)
+
+    # Setting initial position of selected frames
+    cv2.namedWindow("{} selected".format(pair.windows[0]), cv2.WINDOW_AUTOSIZE)
+    cv2.moveWindow("{} selected".format(pair.windows[0]), 0, frames[0].shape[0] + 30)
+
+    cv2.namedWindow("{} selected".format(pair.windows[1]), cv2.WINDOW_AUTOSIZE)
+    cv2.moveWindow("{} selected".format(pair.windows[1]), frames[1].shape[1], frames[1].shape[0] + 30)
 
 
 if __name__ == "__main__":

--- a/bin/capture_chessboards
+++ b/bin/capture_chessboards
@@ -95,6 +95,11 @@ def main():
 
 
 def show_selected_frames(frames, corners, pair, args, draw_corners=False):
+    """
+    Display the most recently captured (left as well as right) images.
+    If draw_corners is set to true, the identified corners are marked on the images.
+    """
+
     if draw_corners:
         for frame, corner in zip(frames, corners):
             cv2.drawChessboardCorners(frame, (args.columns, args.rows), corner, True)
@@ -111,7 +116,6 @@ def enforce_delay(pair, delay):
 
     font = cv2.FONT_HERSHEY_SIMPLEX
     line_type = cv2.LINE_4
-    font_scale = 6.0
     line_thickness = 4
 
     start_time = time.time()
@@ -123,6 +127,10 @@ def enforce_delay(pair, delay):
 
         # Calculates the time remaining before the next sample is captured
         time_remaining = "{:.2f}".format(delay - now + start_time)
+
+        # Estimating the scale factor.
+        font_scale = get_approx_font_scale(frames[0], time_remaining, font, line_thickness)
+
         text_size = cv2.getTextSize(time_remaining, font, font_scale, line_thickness)[0]
 
         # Calculates the position of the text
@@ -138,7 +146,28 @@ def enforce_delay(pair, delay):
         now = time.time()
 
 
+def get_approx_font_scale(frame, text, font, line_thickness):
+    """
+    Approximate the font scale for the timer display.
+    """
+
+    _, width = frame.shape[:2]
+    target_width = width / 2
+
+    base_text_size = cv2.getTextSize(text, font, 1.0, line_thickness)[0]
+    scale_factor = float(target_width) / base_text_size[0]
+
+    return scale_factor
+
+
 def set_window_position(pair):
+
+    """
+    Set initial the positions of windows.
+    The top left and right windows display the live cam stream with timer overlay.
+    The bottom left and right windows display recently selected frame.
+    """
+
     frames = pair.get_frames()
     pair.show_frames(1)
 

--- a/stereovision/stereo_cameras.py
+++ b/stereovision/stereo_cameras.py
@@ -118,15 +118,19 @@ class ChessboardFinder(StereoPair):
         are shown while the cameras search for a chessboard.
         """
         found_chessboard = [False, False]
+
+        # Placeholder for corners
+        found_corners = [None, None]
+
         while not all(found_chessboard):
             frames = self.get_frames()
             if show:
                 self.show_frames(1)
             for i, frame in enumerate(frames):
                 (found_chessboard[i],
-                 corners) = cv2.findChessboardCorners(frame, (columns, rows),
+                 found_corners[i]) = cv2.findChessboardCorners(frame, (columns, rows),
                                                   flags=cv2.CALIB_CB_FAST_CHECK)
-        return frames
+        return frames, found_corners
 
 
 class CalibratedPair(StereoPair):


### PR DESCRIPTION

The capture_chessboards utility is really wonderful. I would like to suggest a few additions to make it
a bit more robust and appealing. The changes are as follows:

1. Enforced the 5 second delay, now independent of the executing machine the delay would be 
	approximately 5 seconds.
	
2. Added a timer overlay on the cam stream. This really helps to properly re-orient the chess_board.
   Furthermore it helps the user to avoid motion blur.
   
3. Two more windows (selected windows) were added to show the snapshot of the last screen captured (both left and right).
	I believe this will help in keeping a mental map of the chess_board orientations.
	The snapshot images are marked with the corners (drawChessboardCorners), to help in gaining a fair approximation as to whether the corners are being detected properly.
	This will also provide a better visual appeal.
	
4. Added a function to provide better starting positions to the windows. The position is not enforced.

I hope these additions would be beneficial.
Please do share your thoughts on same.