### PR TITLE
Update stereo_cameras.py

### DIFF
--- a/stereovision/stereo_cameras.py
+++ b/stereovision/stereo_cameras.py
@@ -83,8 +83,8 @@ class StereoPair(object):
         """
         frame = self.captures[0].read()[1]
         height, width, colors = frame.shape
-        left_frame = frame[:, :width/2, :]
-        right_frame = frame[:, width/2:, :]
+        left_frame = frame[:, :int(width / 2), :]
+        right_frame = frame[:, int(width / 2):, :]
         return [left_frame, right_frame]
 
     def show_frames(self, wait=0):


### PR DESCRIPTION
I am running Python 3.7 and using a single USB synchronized stereo camera delivering side by side images in single frames. I set devices to 0 0 to indicate both frames come from the same camera.

In stereo_cameras.py the function get_frames_singleimage is supposed to slice the single frame into a left and right frame. It returns the error:

Library code:
left_frame = frame[:, :width/2, :]
TypeError: slice indices must be integers or None or have an index method.

The code works properly if changed to make width an integer as below.
left_frame = frame[:, :int(width / 2), :]
right_frame = frame[:, int(width / 2):, :]